### PR TITLE
feature : backgroundOpacityvalue, zoom(캔버스움직임) 제어 props전달

### DIFF
--- a/examples/tldraw-example/src/basic.tsx
+++ b/examples/tldraw-example/src/basic.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 export default function Basic() {
   return (
     <div className="tldraw">
-      <Tldraw />
+      <Tldraw /* disableZoom backgroundOpacityValue={0.5} */ />
     </div>
   )
 }

--- a/packages/core/src/components/Canvas/Canvas.tsx
+++ b/packages/core/src/components/Canvas/Canvas.tsx
@@ -57,6 +57,7 @@ export interface CanvasProps<T extends TLShape, M extends Record<string, unknown
   id?: string
   onBoundsChange: (bounds: TLBounds) => void
   hideCursors?: boolean
+  backgroundOpacityValue?: number
 }
 
 function _Canvas<T extends TLShape, M extends Record<string, unknown>>({

--- a/packages/tldraw/src/Tldraw.tsx
+++ b/packages/tldraw/src/Tldraw.tsx
@@ -118,6 +118,10 @@ export interface TldrawProps extends TDCallbacks {
    * (optional) To hide cursors
    */
   hideCursors?: boolean
+
+  /* (optional) props  */
+  disableZoom?: boolean
+  backgroundOpacityValue?: number
 }
 
 const isSystemDarkMode = window.matchMedia
@@ -140,6 +144,8 @@ export function Tldraw({
   disableAssets = false,
   darkMode = isSystemDarkMode,
   components,
+  disableZoom = false,
+  backgroundOpacityValue = 1,
   onMount,
   onChange,
   onChangePresence,
@@ -253,6 +259,12 @@ export function Tldraw({
     app.setDisableAssets(disableAssets)
   }, [app, disableAssets])
 
+  //Custom Props disableZoom backgroundOpacityValue
+
+  React.useEffect(() => {
+    app.disableZoom = disableZoom
+  }, [app, disableZoom])
+
   // Change the page when the `currentPageId` prop changes.
   React.useEffect(() => {
     if (!currentPageId) return
@@ -356,6 +368,7 @@ export function Tldraw({
           readOnly={readOnly}
           components={components}
           hideCursors={hideCursors}
+          backgroundOpacityValue={backgroundOpacityValue}
         />
       </AlertDialogContext.Provider>
     </TldrawContext.Provider>
@@ -377,6 +390,7 @@ interface InnerTldrawProps {
     Cursor?: CursorComponent
   }
   hideCursors?: boolean
+  backgroundOpacityValue?: number
 }
 
 const InnerTldraw = React.memo(function InnerTldraw({
@@ -392,6 +406,7 @@ const InnerTldraw = React.memo(function InnerTldraw({
   showUI,
   components,
   hideCursors,
+  backgroundOpacityValue,
 }: InnerTldrawProps) {
   const app = useTldrawApp()
   const [dialogContainer, setDialogContainer] = React.useState<any>(null)
@@ -446,6 +461,10 @@ const InnerTldraw = React.memo(function InnerTldraw({
         selectFill: 'rgba(38, 150, 255, 0.05)',
         background: '#212529',
         foreground: '#49555f',
+      }
+    } else {
+      return {
+        background: `rgba(255,255,255, ${backgroundOpacityValue})`,
       }
     }
 

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -220,6 +220,10 @@ export class TldrawApp extends StateManager<TDSnapshot> {
 
   session?: TldrawSession
 
+  /* (optional) props  */
+  disableZoom = false
+  backgroundOpacityValue = 1
+
   readOnly = false
 
   isDirty = false
@@ -2529,6 +2533,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
    * Zoom out by 25%
    */
   zoomIn = (): this => {
+    if (this.disableZoom) return this
     const i = Math.round((this.camera.zoom * 100) / 25)
     const nextZoom = TLDR.getCameraZoom((i + 1) * 0.25)
     return this.zoomTo(nextZoom)
@@ -2538,6 +2543,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
    * Zoom in by 25%.
    */
   zoomOut = (): this => {
+    if (this.disableZoom) return this
     const i = Math.round((this.camera.zoom * 100) / 25)
     const nextZoom = TLDR.getCameraZoom((i - 1) * 0.25)
     return this.zoomTo(nextZoom)
@@ -3742,9 +3748,10 @@ export class TldrawApp extends StateManager<TDSnapshot> {
   }
 
   onZoom: TLWheelEventHandler = (info, e) => {
+    if (this.disableZoom) return
     if (this.state.appState.status !== TDStatus.Idle) return
     const delta = info.delta[2] / 50
-    //this.zoomBy(delta, info.point)
+    this.zoomBy(delta, info.point)
     this.onPointerMove(info, e as unknown as React.PointerEvent)
   }
 


### PR DESCRIPTION
- 기타 관련 문서:[(웅진 스마트올중학 적용 관련 작업 내역)](https://ucompanion.atlassian.net/wiki/spaces/DRAW/pages/634355713)

## Changes

- Zoom 제어 Props(disableZoom: boolean) 전달(ctrl + +-, ctrl + 마우스휠, 우측하단 +-  등 zoom관련 모든 기능 false)
- background 투명도 제어 Props(backgroundOpacityValue: number) 전달

## Test Checklist

- [x] disableZoom 일 때 ctrl + + , ctrl + -, ctrl + 마우스휠 안되는 것을 확인
- [x] disableZoom 일 때 spaceBar + 마우스 좌클릭 으로 캔버스 움직임을 막는 것 확인
- [x] disableZoom 일 때 우측하단 zoom관련 메뉴 zoom 막음
- [x] background 투명도 제어 Props 전달시 적용 확인(다른 tool에는 적용되지 않음을 확인)

## Screenshot
![image](https://user-images.githubusercontent.com/77958517/220503116-fe1f68fd-8082-45d6-add8-badd5c02f048.png)

